### PR TITLE
fix: parse exif via mediainfo tool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,8 +201,13 @@ fn extract_creation_date_native<P: AsRef<Path>>(file_path: P) -> Result<SystemTi
 #[doc(hidden)]
 pub fn parse_date(date: &str) -> SystemTime {
     use chrono::prelude::*;
-    let naive_datetime =
-        NaiveDateTime::parse_from_str(date, "%Y-%m-%dT%H:%M:%S").expect("Failed to parse date");
+
+    let naive_datetime = if date.contains('.') {
+        NaiveDateTime::parse_from_str(date, "%Y-%m-%dT%H:%M:%S%.f")
+    } else {
+        NaiveDateTime::parse_from_str(date, "%Y-%m-%dT%H:%M:%S")
+    }
+    .expect("Failed to parse date");
 
     naive_datetime.and_utc().into()
 }

--- a/src/mediainfo/helper.rs
+++ b/src/mediainfo/helper.rs
@@ -124,8 +124,16 @@ where
 
 fn parse_datetime(datetime: &str) -> Result<SystemTime> {
     let datetime = datetime.trim_start_matches("UTC ").trim_end_matches(" UTC");
-    let datetime: DateTime<Utc> = NaiveDateTime::parse_from_str(datetime, "%Y-%m-%d %H:%M:%S")
-        .map_err(|_| Error::DateTimeParseError(datetime.to_string()))?
+    let format = if datetime.contains('.') {
+        "%Y-%m-%d %H:%M:%S%.f"
+    } else {
+        "%Y-%m-%d %H:%M:%S"
+    };
+    let datetime: DateTime<Utc> = NaiveDateTime::parse_from_str(datetime, format)
+        .map_err(|e| {
+            log::debug!("Failed to parse datetime '{datetime}': {e}");
+            Error::DateTimeParseError(datetime.to_string())
+        })?
         .and_utc();
     Ok(datetime.into())
 }

--- a/tests/tests/mediainfo.rs
+++ b/tests/tests/mediainfo.rs
@@ -20,6 +20,9 @@ fn test_jpg_with_date() -> anyhow::Result<()> {
     let expected = mediameta::MetaData {
         width: 1200,
         height: 800,
+        #[cfg(windows)]
+        creation_date: Some(super::parse_date("2015-07-16T13:34:48.621")), // added in mediainfo 25.04
+        #[cfg(not(windows))]
         creation_date: None,
     };
     assert_eq!(expected, meta);


### PR DESCRIPTION
New release of mediainfo has support for parsing XMP metadata of images
https://mediaarea.net/MediaInfo/ChangeLog